### PR TITLE
Make exports: true for commonjs, just like it is for Node

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -739,7 +739,7 @@
 		"setTimeout": false
 	},
 	"commonjs": {
-		"exports": false,
+		"exports": true,
 		"module": false,
 		"require": false
 	},


### PR DESCRIPTION
The `exports` variable should be assignable for CommonJS as well, am I wrong?
